### PR TITLE
Cleanup

### DIFF
--- a/static/bimatrix/strategy-graph/strategy-graph.js
+++ b/static/bimatrix/strategy-graph/strategy-graph.js
@@ -120,11 +120,13 @@ export class StrategyGraph extends PolymerElement {
             },
             series: [{
                 name: 'Your Choice',
+                type: "area",
                 data: this.myChoiceSeries,
                 step: "left"
             },
             {
                 name: 'Other Choice',
+                type: "line",
                 data: this.otherChoiceSeries,
                 step: "left"
             }],

--- a/static/bimatrix/subperiod-strategy-graph/subperiod-strategy-graph.js
+++ b/static/bimatrix/subperiod-strategy-graph/subperiod-strategy-graph.js
@@ -94,6 +94,7 @@ export class SubperiodStrategyGraph extends PolymerElement {
             },
             plotOptions: {
                 line: {marker: {enabled: false}},
+                area: {marker: {enabled: false}},
                 series: {
                     states: {
                         hover: {
@@ -113,7 +114,7 @@ export class SubperiodStrategyGraph extends PolymerElement {
             },
             series: [{
                 name: 'Your Choice',
-                type: "line",
+                type: "area",
                 data: [[0, 0]],
                 step: "left"
             },

--- a/templates/bimatrix/Decision.html
+++ b/templates/bimatrix/Decision.html
@@ -13,6 +13,7 @@
 
 {% block content %}
     {% with config=subsession.config %}
+        <p>You are now playing Game {{ subsession.round_number }}</p>
         <leeps-bimatrix
             initial-decision='{{ player.initial_decision }}'
             payoff-matrix='{{ config.payoff_matrix }}'

--- a/templates/bimatrix/Payment.html
+++ b/templates/bimatrix/Payment.html
@@ -1,0 +1,20 @@
+{% extends "global/Page.html" %}
+{% load otree static %}
+
+{% block title %}
+    Final Page
+{% endblock %}
+
+{% block content %}
+
+<p>
+Congratulations! You have completed the experiment. The total points you earned in this experiment is {{ participant.payoff }}.
+</p>
+<p>
+    The round which determines your payment was randomly decided as round {{ payoff_round }}. Your payment is {{ payment }} ({{payoff}}).
+    Please press next to end the experiment.
+</p>
+
+    {% next_button %}
+
+{% endblock %}

--- a/templates/bimatrix/Results.html
+++ b/templates/bimatrix/Results.html
@@ -7,20 +7,26 @@
 
 {% block content %}
 
-    <table class="table" style="width:400px; margin-top:20px; margin-bottom:10px">
+    <table class="table" style="width:600px; margin-top:20px; margin-bottom:10px">
         <th>
-            <td>Mix</td>
-            <td>Payoff</td>
+            <td>Up(Left)</td>
+            <td>Bottom(Right)</td>
+            <td>All</td>
+            <td>Payoff in this Game</td>
         </th>
         <tr>
-            <td>Your Avg.</td>
-            <td>{{ my_average_strategy | floatformat:2 }}</td>
+            <td>You</td>
+            <td>{{ freq_top | floatformat:2 }}</td>
+            <td>{{ freq_bottom | floatformat:2 }}</td>
+            <td>{{ 1.00 | floatformat:2 }}</td>
             <td>{{ player.payoff }}</td>
         </tr>
         <tr>
-            <td>Others' Avg.</td>
-            <td>{{ role_average_strategy | floatformat:2 }}</td>
-            <td>{{ role_average_payoff }}</td>
+            <td>Counterparty</td>
+            <td>{{ counter_freq_top | floatformat:2 }}</td>
+            <td>{{ counter_freq_bottom | floatformat:2 }}</td>
+            <td>{{ 1.00 | floatformat:2 }}</td>
+            <td>{{ counter_average_payoff }}</td>
         </tr>
     </table>
 

--- a/views.py
+++ b/views.py
@@ -24,20 +24,6 @@ def get_output_table_header(groups):
     max_num_players = max(len(g.get_players()) for g in groups)
 
     header = [
-        'session_code',
-        'subsession_id',
-        'id_in_subsession',
-        'silo_num',
-        'tick',
-    ]
-
-    for player_num in range(1, max_num_players + 1):
-        header.append('p{}_code'.format(player_num))
-        header.append('p{}_role'.format(player_num))
-        header.append('p{}_strategy'.format(player_num))
-        header.append('p{}_target'.format(player_num))
-
-    header += [
         'payoff1Aa',
         'payoff2Aa',
         'payoff1Ab',
@@ -54,6 +40,21 @@ def get_output_table_header(groups):
         'rate_limit',
         'mean_matching',
     ]
+
+    header += [
+        'session_code',
+        'subsession_id',
+        'id_in_subsession',
+        'silo_num',
+        'tick',
+    ]
+
+    for player_num in range(1, max_num_players + 1):
+        header.append('p{}_code'.format(player_num))
+        header.append('p{}_role'.format(player_num))
+        header.append('p{}_strategy'.format(player_num))
+        header.append('p{}_target'.format(player_num))
+
     return header
 
 
@@ -90,7 +91,9 @@ def get_output_cont_time(events):
                 targets[e.participant.code] = e.value
         if cur_decision_event:
             decisions.update(cur_decision_event.value)
-        row = [
+        row = []
+        row += config_columns
+        row += [
             group.session.code,
             group.subsession_id,
             group.id_in_subsession,
@@ -108,7 +111,6 @@ def get_output_cont_time(events):
                     decisions[pcode],
                     targets[pcode],
                 ]
-        row += config_columns
         rows.append(row)
     return rows
 
@@ -126,6 +128,8 @@ def get_output_discrete_time(events):
         if event.channel == 'target':
             targets[event.participant.code] = event.value
         elif event.channel == 'group_decisions':
+            row = []
+            row += config_columns
             row = [
                 group.session.code,
                 group.subsession_id,
@@ -144,7 +148,6 @@ def get_output_discrete_time(events):
                         event.value[pcode],
                         targets[pcode],
                     ]
-            row += config_columns
             rows.append(row)
             tick += 1
     return rows


### PR DESCRIPTION
Changes as requested by Shuchen
- changed the dataset in the correlated equilibrium projects so that the session-related columns are on the left and player-related columns on the right
- updated the results page; created table showing the frequency of player's choices and counterparty's choices
- set the timeout_limit on the result page to 15 seconds.
- added a final page at the end of the last round to show subjects their total payoff; randomly chose one round and showed subjects that they are paid by that round.
- On the decision page, added a line of sentence on the top left that says "You are now playing Game X", where X is the round number.